### PR TITLE
update repository url, otherwise ReasonPhrase: Forbidden. As of Febru…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,11 @@
  <distributionManagement>
   <snapshotRepository>
    <id>ossrh</id>
-   <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+   <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
   </snapshotRepository>
   <repository>
    <id>ossrh</id>
-   <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+   <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
   </repository>
  </distributionManagement>
 


### PR DESCRIPTION
update repository url, otherwise ReasonPhrase: Forbidden.  As of February 2021, all new projects began being provisioned on https://s01.oss.sonatype.org/. If your project is not provisioned on https://s01.oss.sonatype.org/, you will want to login to the legacy host https://oss.sonatype.org/.  
https://central.sonatype.org/publish/publish-guide/#releasing-to-central